### PR TITLE
Remove r-testthat dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,11 @@ source:
   sha256: bfd165cea084de567cde1406a6dbdf4e9b6da1706699365a2386cb8938c2bed8
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win]
   rpaths:
     - lib/R/lib/
     - lib/
-  ignore_run_exports: # ignore here to avoid overlink warning b/c test require doesn't work
-    - r-testthat
 
 requirements:
   build:
@@ -31,7 +29,6 @@ requirements:
     - r-base
     - tiledb 2.11.*
     - r-rcpp >=0.12.15
-    - r-testthat
     - r-nanotime
   run:
     - r-base


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Background:

* Package originally used testing framework testthat
  https://github.com/TileDB-Inc/TileDB-R/issues/6
  https://github.com/conda-forge/staged-recipes/pull/10709
* Switched to using tinytest
  https://github.com/TileDB-Inc/TileDB-R/issues/147
* Updated how the recipe ran the tests but not the dependencies
  https://github.com/conda-forge/r-tiledb-feedstock/pull/11
  https://github.com/conda-forge/r-tiledb-feedstock/commit/184d85f2e08fe8e9c703594488de478131a0aa2e