### PR TITLE
Update TileDB pin to 2.15

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-skip-osx-test-to-avoid-spurious-segfault.patch  # [osx and not arm64]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   rpaths:
     - lib/R/lib/
@@ -29,7 +29,7 @@ requirements:
     - r-rcppspdlog  # [build_platform != target_platform]
   host:
     - r-base
-    - tiledb 2.14.*
+    - tiledb 2.15.*
     - r-rcpp >=1.0.8
     - r-rcppspdlog
     - r-nanotime
@@ -37,7 +37,7 @@ requirements:
   run:
     - r-base
     - r-nanotime
-    - tiledb 2.14.*
+    - tiledb 2.15.*
     - r-spdl
 
 test:


### PR DESCRIPTION
Update TileDB pin to 2.15.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
