### PR TITLE
Remove tiledb from run reqs. Rely on "run exports"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,21 @@
 # Everything else is managed by the conda-smithy rerender process.
 # Please do not modify
 
+# Ignore all files and folders in root
 *
 !/conda-forge.yml
 
+# Don't ignore any subfolders if the parent folder is 'un-ignored'
 !/*/
+# Don't ignore any files/folders recursively in the following folders
 !/recipe/**
 !/.ci_support/**
+
+# Since we ignore files/folders recursively, any folders inside
+# build_artifacts gets ignored which trips some build systems.
+# To avoid that we 'un-ignore' all files/folders recursively
+# and only ignore the root build_artifacts folder.
+!/build_artifacts/**
+/build_artifacts
 
 *.pyc

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -57,12 +57,6 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
   cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
 fi
 
-if [[ "${sha:-}" == "" ]]; then
-  pushd ${FEEDSTOCK_ROOT}
-  sha=$(git rev-parse HEAD)
-  popd
-fi
-
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -21,6 +21,12 @@ if [ -z ${FEEDSTOCK_NAME} ]; then
     export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
 fi
 
+if [[ "${sha:-}" == "" ]]; then
+  pushd "${FEEDSTOCK_ROOT}"
+  sha=$(git rev-parse HEAD)
+  popd
+fi
+
 docker info
 
 # In order for the conda-build process in the container to write to the mounted

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-skip-osx-test-to-avoid-spurious-segfault.patch  # [osx and not arm64]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   rpaths:
     - lib/R/lib/
@@ -39,7 +39,6 @@ requirements:
   run:
     - r-base
     - r-nanotime
-    - tiledb 2.19.*
     - r-spdl
 
 test:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

---

The tiledb recipe uses ["run exports"](https://conda.io/projects/conda-build/en/latest/resources/define-metadata.html#export-runtime-requirements). This means that it is automatically installed at runtime using the defined pinning:

https://github.com/conda-forge/tiledb-feedstock/blob/5626a0dad734250ef17a6ca9bed0cb9d1fd2feee/recipe/meta.yaml#L17

```yaml
  run_exports:
    # https://abi-laboratory.pro/?view=timeline&l=tiledb
    - {{ pin_subpackage('tiledb', max_pin='x.x') }}
```

Thus when the recipe also includes `tiledb 2.19.*` in the run requirements, best case scenario it is simply redundant, which can be seen by rendering the recipe locally:

```sh
wget https://raw.githubusercontent.com/conda-forge/conda-forge-pinning-feedstock/main/recipe/conda_build_config.yaml
conda render -m conda_build_config.yaml recipe/
##  run:
##    - tiledb >=2.19.0,<2.20.0a0
##    - tiledb 2.19.*
```

Thus typically the only convenience is that we have to manually bump two pins instead of one. However, today I think I have discovered a more severe downside. When trying to solve the conda environment for tiledbsoma-feedstock in https://github.com/TileDB-Inc/tiledbsoma-feedstock/pull/74, I noticed that tiledb is inserted into the host requirements of r-tiledbsoma but not tiledbsoma-py (https://github.com/TileDB-Inc/tiledbsoma-feedstock/pull/74#issuecomment-1885390407). This makes it more difficult to solve all 3 different envs (C++, Python, and R). The tiledb-py recipe does not include tiledb in its run requirements, so I am hopeful that removing it from r-tiledb will make future updates to tiledbsoma-feedstock go more smoothly.

And a more general note, we should really remove tiledb and other shared libraries that use "run exports" from the run requirements of all our tiledb-related recipes. I've been fixing recipes whenever I have been updating them for other reasons. We need to trust the "run exports" pinning that we have decided on to handle runtime version pinning (https://github.com/conda-forge/tiledb-feedstock/pull/215)

